### PR TITLE
fix(cc-checkbox/cc-radio): 修复默认值错误、界面显示错误

### DIFF
--- a/demos/checkbox/index.html
+++ b/demos/checkbox/index.html
@@ -22,7 +22,8 @@
 	<p>setting ng-model of the component.</p>
 	value: {{demo1}}<br/>
 	<cc-checkbox ng-model="demo1">demo1: using ng-model</cc-checkbox>
-	<cc-checkbox ng-model="demo1">demo1: another checkbox</cc-checkbox>
+	<cc-checkbox ng-model="demo1">demo1: using ng-model</cc-checkbox>
+	<cc-checkbox>no model</cc-checkbox>
 	<button ng-click="demo1 = !demo1">change model value</button>
 </div>
 <div>

--- a/demos/checkbox/index.js
+++ b/demos/checkbox/index.js
@@ -12,7 +12,6 @@
 		.module('app', ['ccms.components'])
 		.controller('ctrl', function ($scope) {
 
-			$scope.demo1 = false;
 			$scope.demo2 = false;
 			$scope.demo3 = {
 				trueValue: 'up',

--- a/src/components/checkbox/CheckboxCtrl.js
+++ b/src/components/checkbox/CheckboxCtrl.js
@@ -12,6 +12,7 @@ export default class CheckboxController {
 	$onInit() {
 		this.ngTrueValue = this.ngModelController ? (typeof this.ngTrueValue === 'undefined' ? true : this.ngTrueValue) : true;
 		this.ngFalseValue = this.ngModelController ? (typeof this.ngFalseValue === 'undefined' ? false : this.ngFalseValue) : false;
+		this.ngChecked = ('ngModel' in this) ? this.ngModel === this.ngTrueValue : this.ngChecked;
 	}
 
 	/**

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -10,6 +10,10 @@ $disabled-color: #D1D1D1;
 
 cc-checkbox{
   display: inline-block;
+
+  * {
+	box-sizing: border-box;
+  }
 }
 
 .cc-checkbox{
@@ -29,8 +33,8 @@ cc-checkbox{
 	border: solid 1px $normal-border-color;
 	border-radius: $default-border-width;
 	position: relative;
-	width: (14 / $font-size-number) + em;
-	height: (14 / $font-size-number) + em;
+	width: (16 / $font-size-number) + em;
+	height: (16 / $font-size-number) + em;
 	margin-right: 1em;
 
 	&:before{

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -10,6 +10,10 @@ $disabled-color: #D1D1D1;
 
 cc-radio{
   display: inline-block;
+
+  * {
+	box-sizing: border-box;
+  }
 }
 
 .cc-radio{
@@ -29,8 +33,8 @@ cc-radio{
 	border: solid 1px $normal-border-color;
 	border-radius: 50%;
 	position: relative;
-	width: (14 / $font-size-number) + em;
-	height: (14 / $font-size-number) + em;
+	width: (16 / $font-size-number) + em;
+	height: (16 / $font-size-number) + em;
 	margin-right: 1em;
 
 	&:before{


### PR DESCRIPTION
修复： checkbox ng-model 值未设置时，默认选中
修复： 组件在 modal 中因 box-sizing: border-box 引起的组件位置错误