### PR TITLE
fix(modal):modal close时需提前移除listener,而不是在removeClass callback中再移除

### DIFF
--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -122,6 +122,9 @@ export default class Modal extends Popup {
 	close() {
 		this.element.removeChild(this._modalContainer || this._confirmContainer);
 
+		window.removeEventListener('resize', this._resizeModal);
+		window.removeEventListener('hashchange', this.close);
+
 		// force firefox to repaint for attaching trasitionend/animationend event
 		if (isFirefox) {
 			this.element.offsetHeight;
@@ -135,9 +138,6 @@ export default class Modal extends Popup {
 			if (this.element.$scope && typeof this.element.$scope.$destroy === 'function') {
 				this.element.$scope.$destroy();
 			}
-
-			window.removeEventListener('resize', this._resizeModal);
-			window.removeEventListener('hashchange', this.close);
 
 			this.destroy();
 		});


### PR DESCRIPTION
removeClass callback中再移除 hashchange listener 会出现 remove callback 比 hashchange 晚触发的异步问题