### PR TITLE
fix(customer-profile-board):客户全视图需要兼容jquery

### DIFF
--- a/demos/customer-profile-board/index.html
+++ b/demos/customer-profile-board/index.html
@@ -3,6 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>customer-profile-board</title>
+	<!-- 引入 Jquery 进行兼容性测试 -->
+	<script src="https://shuyun-static.b0.upaiyun.com/components/jquery/1.7.1.1/jquery-1.7.1.min.js"></script>
 </head>
 <body ng-app="app" ng-controller="ctrl" style="padding: 20px">
 <h1>Customer profile board Demo</h1>

--- a/src/components/customer-profile-board/CustomerProfileBoardCtrl.js
+++ b/src/components/customer-profile-board/CustomerProfileBoardCtrl.js
@@ -9,7 +9,7 @@ import { Inject } from 'angular-es-utils';
 import CustomerAttributeSetting from './CustomerAttributeSetting.js';
 import CustomerProfileBoardService from './CustomerProfileBoardService.js';
 
-@Inject('$element', '$scope')
+@Inject('$element', '$scope', '$timeout')
 export default class CheckboxController {
 	constructor() {
 		this.customerAttributeSetting = CustomerAttributeSetting;
@@ -72,8 +72,8 @@ export default class CheckboxController {
 	 * According to index, scroll view to special block
 	 */
 	scrollToAttributeBlock(index = 0) {
-		this._$element.ready(() => {
+		this._$timeout(() => {
 			this._$element[0].querySelectorAll('customer-attribute-editor')[index].scrollIntoView();
-		});
+		}, 0, false);
 	}
 }

--- a/src/components/customer-profile-board/customer-profile-list-mode/CustomerProfileListModeCtrl.js
+++ b/src/components/customer-profile-board/customer-profile-list-mode/CustomerProfileListModeCtrl.js
@@ -7,7 +7,7 @@
 import { Inject } from 'angular-es-utils';
 import { Debounce } from 'angular-es-utils/decorators';
 
-@Inject('$element')
+@Inject('$element', '$timeout')
 export default class CustomerProfileListModeCtrl {
 	constructor() {
 		this.rightPanelScrollListener = this.rightPanelScrollListener.bind(this);
@@ -28,9 +28,9 @@ export default class CustomerProfileListModeCtrl {
 	 * generator attributes block offset list
 	 */
 	$postLink() {
-		this._$element.ready(() => {
+		this._$timeout(() => {
 			this.attributesOffsetList = this.getAttributeBlockOffsetList();
-		});
+		}, 0, false);
 	}
 
 	/**


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/4166657/17686488/7bbc4a24-639f-11e6-8c83-8f59a8846a94.png)

原因，老系统中引入的Jquery ready 方法会替换掉 AngularJS 中的 Jqlite 中的 ready 方法，两个方法实现有些不太一样，Jqlite 在页面加载完成之后再调用，始终会将函数加到 settimeout 中， 然而 jquery 的ready 方法只是返回一个 promise， 当你切换到 list view 时，未在 dom 渲染之后执行 获取 dom 执行scrollIntoView，所以 undefined， 所以需要将 这个 dom 操作加到 event queue 中，当 dom 渲染完成后再执行 dom 操作.  


