### PR TITLE
fix(dropdown-select):当搜索后再将modal置为空时，下拉中的items应该为完整的datalist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CCMS Components 
-[![Build Status](https://img.shields.io/travis/ShuyunFF2E/ccms-components/master.svg?style=flat)](https://travis-ci.org/ShuyunFF2E/ccms-components) 
-[![npm version](https://img.shields.io/npm/v/ccms-components.svg?style=flat)](https://www.npmjs.com/package/ccms-components)
-[![npm downloads](https://img.shields.io/npm/dt/ccms-components.svg?style=flat)](https://www.npmjs.com/package/ccms-components)
-[![coverage](https://img.shields.io/codecov/c/github/ShuyunFF2E/ccms-components/dev.svg?style=flat)](https://www.npmjs.com/package/ccms-components)
+[![Build Status](https://img.shields.io/travis/ShuyunFF2E/ccms-components/master.svg?style=flat-square)](https://travis-ci.org/ShuyunFF2E/ccms-components) 
+[![npm version](https://img.shields.io/npm/v/ccms-components.svg?style=flat-square)](https://www.npmjs.com/package/ccms-components)
+[![npm downloads](https://img.shields.io/npm/dt/ccms-components.svg?style=flat-square)](https://www.npmjs.com/package/ccms-components)
+[![coverage](https://img.shields.io/codecov/c/github/ShuyunFF2E/ccms-components/dev.svg?style=flat-square)](https://www.npmjs.com/package/ccms-components)
 
 [组件 API 文档](http://shuyunff2e.github.io/ccms-components/components/)
 

--- a/src/components/dropdown/dropdown-select/DropdownSelectCtrl.js
+++ b/src/components/dropdown/dropdown-select/DropdownSelectCtrl.js
@@ -177,12 +177,12 @@ export default class DropdownSelectCtrl {
 		} else {
 			this.title = '';
 			this.model = null;
+			this.items = this._clampedDatalist;
 		}
 	}
 
 	clear() {
 		this.setModelValue(null);
-		this.items = this._getClampedDatalist(this.datalist);
 		this.getInputElement().focus();
 		this.focusAt(0);
 	}


### PR DESCRIPTION
**在单选可搜索的dropdown中**

当搜索后再置为空时：
![1](https://cloud.githubusercontent.com/assets/19797722/18621903/ec1ce7c0-7e5b-11e6-9283-9996a92650b4.jpg)

点击下拉图标，下拉中的items没有更新：
![2](https://cloud.githubusercontent.com/assets/19797722/18621940/3428a63a-7e5c-11e6-9417-796429445463.jpg)

