### PR TITLE
Revert "feat(package): update dependence: angular-es-utils@2.1.2 (#318)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "angular": "^1.5.8",
-    "angular-es-utils": "^2.1.2",
+    "angular-es-utils": "^1.3.1",
     "angular-resource": "^1.5.8",
     "angular-ui-router": "^0.2.18",
     "jquery": "1.11.0",


### PR DESCRIPTION
@kuitos, angular-es-utils 升级到 2.1.2 时 `npm run test:cover` 失败。