### PR TITLE
fix(menu):修复 Menu 的 onUnfold 的钩子

### DIFF
--- a/src/components/menus/index.js
+++ b/src/components/menus/index.js
@@ -27,7 +27,7 @@ const
 		controllerAs: 'menus',
 		bindings: {
 			unfold: '=',
-			onUnfold: '=?',
+			onUnfold: '&?',
 			menuSource: '<',
 			shopSource: '<?',
 			searchPlaceholder: '<?'


### PR DESCRIPTION
应该是 onUnfold: '&?',  而不是 onUnfold: '=?',


