### PR TITLE
fix(sms-editor):初始化短信内容,不应该加prefix和suffix

### DIFF
--- a/src/components/sms-editor/SMSEditorCtrl.js
+++ b/src/components/sms-editor/SMSEditorCtrl.js
@@ -184,8 +184,7 @@ export default class SMSEditorCtrl {
 	 */
 	parseTag(text = '') {
 		return SMSEditorCtrl.flatCode(text).replace(/\$\$_(?:\[(\S*?)])?(.+?)_\$\$/g, (result, $1, $2) => {
-			const keyword = this.getKeywordConfig($2, false);
-			return this.createInput(this.keywordTextNameConvert($2, false), $1, keyword && keyword.prefix, keyword && keyword.suffix);
+			return this.createInput(this.keywordTextNameConvert($2, false), $1);
 		});
 	}
 

--- a/src/components/sms-preview/SMSPreview.js
+++ b/src/components/sms-preview/SMSPreview.js
@@ -20,7 +20,7 @@ export default {
 		const opts = scope.opts || (scope.opts = {});
 		const trimContent = angular.isDefined(opts.trimContent) ? opts.trimContent : true;
 		scope.smsPreviewStatText = trimContent ? '不含变量' : '含空格，不含变量';
-		scope.smsPreviewTipsText = trimContent ? '上图仅为操作预览，最终计数以实际发送为准，查看' : '上图仅为操作预览，变量无固定长度，最终计数以实际发送为准，强烈建议先测试执行，查看';
+		scope.smsPreviewTipsText = trimContent ? '上图仅为操作预览，最终计数以实际发送为准，查看' : '上图仅为操作预览，变量无固定长度，最终计数以实际发送为准，建议先测试执行，查看';
 
 		scope.$watch('opts', () => {
 			const varReg = /\$\$_(\[[^]]+])?(.+?)_\$\$/g;


### PR DESCRIPTION
1.初始化短信内容,不应该加prefix和suffix
2.修改短信预览下方的提示文案