### PR TITLE
Fix(grid):grid hidden columns issue

### DIFF
--- a/demos/components/grid/index.js
+++ b/demos/components/grid/index.js
@@ -144,7 +144,7 @@ angular.module('componentsApp', ['ccms.components', 'ngResource'])
 					align: 'left'
 				},
 				{field: 'age', displayName: '年龄', align: 'center'},
-				{field: 'gender', displayName: '性别', align: 'right', isHidden: true, tooltip: '这是一个测试'}
+				{field: 'gender', displayName: '性别(这是一个超长的 column 名称)', align: 'right', isHidden: true, tooltip: '这是一个测试'}
 			],
 			enableHiddenColumns: true,
 			showPagination: false

--- a/src/components/checkbox/CheckboxCtrl.js
+++ b/src/components/checkbox/CheckboxCtrl.js
@@ -28,8 +28,12 @@ export default class CheckboxController {
 	 * @name toggleClick
 	 * toggle the checked value when user click the checkbox
 	 */
-	toggleClick() {
-		if (this.ngDisabled) return false;
+	toggleClick($event) {
+		if (this.ngDisabled) {
+			// 当 checkbox 不可用时, 阻止其它注册的 click listener
+			$event.stopImmediatePropagation();
+			return false;
+		}
 		this.indeterminate = false;
 		this.ngChecked = !this.ngChecked;
 		this.ngModelController && this.updateNgModel(this.ngChecked);

--- a/src/components/checkbox/__tests__/test-CheckboxCtrl.js
+++ b/src/components/checkbox/__tests__/test-CheckboxCtrl.js
@@ -9,7 +9,7 @@ import { assert } from 'chai';
 import CheckboxCtrl from '../CheckboxCtrl.js';
 
 describe('CheckboxCtrl', () => {
-	let checkboxCtrl, bindings;
+	let checkboxCtrl, bindings, $event, marked;
 
 	before(() => {
 		checkboxCtrl = new CheckboxCtrl();
@@ -18,6 +18,14 @@ describe('CheckboxCtrl', () => {
 		checkboxCtrl.ngModelController = {
 			$setViewValue: function(value) {
 				checkboxCtrl.ngModel = value;
+			}
+		};
+
+		marked = 0;
+
+		$event = {
+			stopImmediatePropagation() {
+				marked++;
 			}
 		};
 	});
@@ -54,7 +62,8 @@ describe('CheckboxCtrl', () => {
 
 	it('toggleClick', () => {
 		assert.deepEqual(checkboxCtrl.ngChecked, true);
-		checkboxCtrl.toggleClick();
+		checkboxCtrl.toggleClick($event);
+		assert.equal(marked, 0);
 		assert.deepEqual(checkboxCtrl.ngChecked, false);
 		assert.deepEqual(checkboxCtrl.ngModel, 'f');
 
@@ -62,7 +71,8 @@ describe('CheckboxCtrl', () => {
 			ngDisabled: true
 		};
 		Object.assign(checkboxCtrl, bindings);
-		checkboxCtrl.toggleClick();
+		checkboxCtrl.toggleClick($event);
+		assert.equal(marked, 1);
 		assert.deepEqual(checkboxCtrl.ngChecked, false);
 		assert.deepEqual(checkboxCtrl.ngModel, 'f');
 
@@ -72,7 +82,8 @@ describe('CheckboxCtrl', () => {
 		};
 		Object.assign(checkboxCtrl, bindings);
 		assert.deepEqual(checkboxCtrl.indeterminate, true);
-		checkboxCtrl.toggleClick();
+		checkboxCtrl.toggleClick($event);
+		assert.equal(marked, 1);
 		assert.deepEqual(checkboxCtrl.indeterminate, false);
 		assert.deepEqual(checkboxCtrl.ngChecked, true);
 		assert.deepEqual(checkboxCtrl.ngModel, 't');

--- a/src/components/checkbox/checkbox.tpl.html
+++ b/src/components/checkbox/checkbox.tpl.html
@@ -1,3 +1,3 @@
-<div class="cc-checkbox" ng-click="$ctrl.toggleClick()" ng-class="{ 'checked': $ctrl.ngChecked, 'disabled': $ctrl.ngDisabled, 'indeterminate': $ctrl.indeterminate }">
+<div class="cc-checkbox" ng-click="$ctrl.toggleClick($event)" ng-class="{ 'checked': $ctrl.ngChecked, 'disabled': $ctrl.ngDisabled, 'indeterminate': $ctrl.indeterminate }">
 	<div class="cc-checkbox-input"></div><div class="cc-checkbox-label" ng-transclude></div>
 </div>

--- a/src/components/grid/_grid.scss
+++ b/src/components/grid/_grid.scss
@@ -124,7 +124,7 @@ cc-grid {
 				top: 100%;
 				right: -1px;
 				z-index: 1;
-				width: 156px;
+				width: 168px;
 				max-height: 162px;
 				overflow: auto;
 				border: solid 1px #ccc;
@@ -141,6 +141,11 @@ cc-grid {
 					cc-checkbox {
 						width: 100%;
 						padding: 8px;
+						span {
+							width: 118px;
+							display: inline-block;
+							@include cut-long-text;
+						}
 					}
 				}
 			}

--- a/src/components/grid/tpls/default-header.tpl.html
+++ b/src/components/grid/tpls/default-header.tpl.html
@@ -26,7 +26,7 @@
 				<cc-checkbox
 						ng-disabled="!column.isHidden && $ctrl.getShownColumnsCount() === 1"
 						ng-checked="!column.isHidden"
-						ng-click="$ctrl.toggleColumnByIndex($index)">{{ column.displayName }}</cc-checkbox>
+						ng-click="$ctrl.toggleColumnByIndex($index)" title={{column.displayName}}>{{ column.displayName }}</cc-checkbox>
 			</li>
 		</ul>
 	</div>


### PR DESCRIPTION
1.当 column 列太长时候，样式问题
2.cc-checkbox ng-disabled 并未禁止调用 ng-click 注册的事件
![hiddencolumns](https://user-images.githubusercontent.com/4166657/29018179-b2b48540-7b8c-11e7-8a8e-d83e53837594.jpg)

