### PR TITLE
fix(dropdown):不能初始化预设值,当启用search时

### DIFF
--- a/demos/components/select/index.html
+++ b/demos/components/select/index.html
@@ -118,7 +118,7 @@
 	angular.module('demoApp', ['ccms.components'])
 		.controller('DemoCtrl', function() {
 			this.value1 = '上海';
-			this.value2 = null;
+			this.value2 = 'xa';
 			this.value3 = [];
 			this.value4 = ['xa', 'sh'];
 			this.value5 = '上海';

--- a/src/components/dropdown/dropdown-select/DropdownSelectCtrl.js
+++ b/src/components/dropdown/dropdown-select/DropdownSelectCtrl.js
@@ -44,6 +44,9 @@ export default class DropdownSelectCtrl {
 
 	_prepareOptions() {
 		const defaultMapping = DropdownSelectCtrl.defaultMapping;
+		// TODO: https://github.com/ShuyunFF2E/ccms-components/issues/397, 原因待调研, 一个临时方案:
+		// 在 _prepareWatches 中的第一个 watch 回调函数中访问 this.model 时, 为 null, 所以临时保存一份, 用于初始化值
+		this.initModelValue = this.model;
 		this.mapping = Object.assign({}, defaultMapping, this.mapping);
 
 		if (typeof this.autoClose !== 'undefined' && this.autoClose !== false) {
@@ -64,7 +67,7 @@ export default class DropdownSelectCtrl {
 			this.items = this._clampedDatalist = this._getClampedDatalist(datalist || []);
 
 			// 选中预设值
-			this.setModelValue(this.model);
+			this.setModelValue(this.model || this.initModelValue);
 			// 设置预设值的 focusIndex
 			this.focusAt(this.getItemIndexByItemValue(this.model, this.items));
 		});

--- a/src/components/dropdown/dropdown-select/DropdownSelectCtrl.js
+++ b/src/components/dropdown/dropdown-select/DropdownSelectCtrl.js
@@ -44,10 +44,8 @@ export default class DropdownSelectCtrl {
 
 	_prepareOptions() {
 		const defaultMapping = DropdownSelectCtrl.defaultMapping;
-		// TODO: https://github.com/ShuyunFF2E/ccms-components/issues/397, 原因待调研, 一个临时方案:
-		// 在 _prepareWatches 中的第一个 watch 回调函数中访问 this.model 时, 为 null, 所以临时保存一份, 用于初始化值
-		this.initModelValue = this.model;
 		this.mapping = Object.assign({}, defaultMapping, this.mapping);
+		this.items = this._getClampedDatalist(this.datalist || []);
 
 		if (typeof this.autoClose !== 'undefined' && this.autoClose !== false) {
 			this.autoClose = true;
@@ -65,9 +63,8 @@ export default class DropdownSelectCtrl {
 
 		scope.$watch(() => this.datalist, (datalist, oldDatalist) => {
 			this.items = this._clampedDatalist = this._getClampedDatalist(datalist || []);
-
 			// 选中预设值
-			this.setModelValue(this.model || this.initModelValue);
+			this.setModelValue(this.model);
 			// 设置预设值的 focusIndex
 			this.focusAt(this.getItemIndexByItemValue(this.model, this.items));
 		});


### PR DESCRIPTION
原因待调研, 一个临时方案:
在 _prepareWatches 中的第一个 watch 回调函数中访问 this.model 时, 为 null,  所以临时保存一份, 用于初始化值, 至于为什么 this.model 为空，原因不明。