### PR TITLE
fix(date-picker):click on (disabled) input not getting triggered on firefox

### DIFF
--- a/src/components/date-picker/_date-picker.scss
+++ b/src/components/date-picker/_date-picker.scss
@@ -49,6 +49,7 @@ $normal-color:	#c9c9c9;
     &.disabledInput .date-picker-input {
 	 	background: #fff;
 		color: #3d3d3d;
+	    pointer-events: none;
   	}
 
 	.date-picker-input-year {


### PR DESCRIPTION
1.click on (disabled) input not getting triggered on firefox.
2.https://bugzilla.mozilla.org/show_bug.cgi?id=218093
3.https://stackoverflow.com/questions/3100319/event-on-a-disabled-input